### PR TITLE
Fixed typo in README and simplified setup.py

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-taxodb.py is a simple python program that it uses to format the NCBI Taxonomy Database (http://www.ncbi.nlm.nih.gov/taxonomy).  
+taxodb.py is a simple python program that it used to format the NCBI Taxonomy Database (http://www.ncbi.nlm.nih.gov/taxonomy).
 It requires the bsddb3 python library (https://pypi.python.org/pypi/bsddb3) and Berkeley DB library (http://www.oracle.com) to work. 
 
 DATA:
@@ -14,7 +14,7 @@ Get Taxonomy Database of NCBI:
 
 Get help:
 
- $ python ./taxodb.py -h
+ $ python taxodb.py -h
 
 Get text and Berkeley DB database format:
 

--- a/setup.py
+++ b/setup.py
@@ -1,68 +1,30 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from distutils.core import setup
-from distutils.command.install_egg_info import install_egg_info
-from distutils.versionpredicate import VersionPredicate
-from distutils.command.build import build
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 import sys
+if (sys.version_info[0] == 2 and sys.version_info[1] < 7) or (sys.version_info[0] >= 3):
+    sys.exit('Python version >= 2.7 and < 3.0')
 
+config = {
+    'name': 'taxodb_ncbi',
+    'author': 'Corinne Maufrais',
+    'version': '2.0',
+    'author_email': 'corinne.maufrais@pasteur.fr',
+    'url': 'https://github.com/C3BI-pasteur-fr/taxodb_ncbi',
+    'download_url': 'https://github.com/C3BI-pasteur-fr/taxodb_ncbi',
+    'license': 'GPLv3',
+    'description': """taxodb.py is a simple python program that it used to format the NCBI Taxonomy Database
+                   (http://www.ncbi.nlm.nih.gov/taxonomy).
+                   It requires the bsddb python library (https://docs.python.org/2/library/bsddb.html) and Berkeley DB
+                   library (http://www.oracle.com/database/berkeley-db) to work.""",
+    'package_dir': {'': 'src'},
+    'scripts': ['src/taxodb.py',
+                'src/taxodb_extended.py'],
+    'install_requires': ['bsddb3']
+}
 
-class nohup_egg_info(install_egg_info):
-    def run(self):
-        # there is nothing to install in sites-package
-        # so I don't put any eggs in it
-        pass
-
-
-class check_and_build(build):
-    def run(self):
-        chk = True
-        for req in require_pyt:
-            chk &= self.chkpython(req)
-        for req in require_mod:
-            chk &= self.chkmodule(req)
-        if not chk:
-            sys.exit(1)
-        build.run(self)
-
-    def chkpython(self, req):
-        chk = VersionPredicate(req)
-        ver = '.'.join([str(v) for v in sys.version_info[:2]])
-        if not chk.satisfied_by(ver):
-            print >> sys.stderr, "Invalid python version, expected %s" % req
-            return False
-        return True
-
-    def chkmodule(self, req):
-        chk = VersionPredicate(req)
-        try:
-            mod = __import__(chk.name)
-        except:
-            print >> sys.stderr, "Missing mandatory %s python module" % chk.name
-            return False
-        for v in ['__version__', 'version']:
-            ver = getattr(mod, v, None)
-            break
-        try:
-            if ver and not chk.satisfied_by(ver):
-                print >> sys.stderr, "Invalid module version, expected %s" % req
-                return False
-        except:
-            pass
-        return True
-
-require_pyt = ['python (>=2.7, <3.0)']
-require_mod = ['bsddb']
-
-
-setup(name = "taxodb_ncbi",
-      version="2.0",
-      author="Corinne Maufrais",
-      author_email="corinne.maufrais@pasteur.fr",
-      license='GPLv3',
-      description = ("""taxodb.py is a simple python program that it uses to format the NCBI Taxonomy Database (http://www.ncbi.nlm.nih.gov/taxonomy).  
-It requires the bsddb python library (https://docs.python.org/2/library/bsddb.html) and Berkeley DB library (http://www.oracle.com/database/berkeley-db) to work."""),
-      cmdclass={'install_egg_info': nohup_egg_info},
-      package_dir={'': 'src'},
-      install_requires = ['bsddb >=6.1.0',],
-) 
+setup(**config)


### PR DESCRIPTION
Hi,

I've made some changes into your `README` mainly for typos.
I've also rewrite the `setup.py` because using it as it was, it was impossbile to install your scripts:

```
$ python setup.py install
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
running install
running build
running install_egg_info
$  taxodb.py
bash: /path/to/project/taxodb_ncbi/bin/taxodb.py: No such file or directory
```

I hope these modifications are ok?
If so, it maybe should be good to create a new release (e.g.: `1.1` or `2.0`)

Regards
Emmanuel
