### PR TITLE
Fix Unix default mode to 0666

### DIFF
--- a/src/taxodb_ncbi.py
+++ b/src/taxodb_ncbi.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
         # Create a database in file "osVSocDB" with a Hash access method
         #       There are also, B+tree and Recno access methods
         try:
-            os_vs_oc_bdb.open(args.os_vs_oc, None, db.DB_HASH, db.DB_CREATE)
+            os_vs_oc_bdb.open(args.os_vs_oc, None, db.DB_HASH, db.DB_CREATE, mode=0666)
         except db.DBAccessError as msg:
             print >> sys.stderr, "Error: %s %s" % (args.os_vs_oc, msg)
             sys.exit(1)


### PR DESCRIPTION
Hi,

Would it be possible to integrate this pull request? This fixes the default Unix mode creation of the Berkeley db on disk from `0660` (default https://www.jcea.es/programacion/pybsddb_doc/db.html#db-methods) to `0666`.
Thus it is also consistent with the other mode created in pack `taxo_rrna`.

Cheers

Manu
